### PR TITLE
Comment out J2 computation since it can cause divide-by-zero errors

### DIFF
--- a/solver/kineticTheoryModels/kineticTheoryModel/kineticTheoryModel.C
+++ b/solver/kineticTheoryModels/kineticTheoryModel/kineticTheoryModel.C
@@ -373,9 +373,11 @@ void Foam::kineticTheoryModel::solve
 
     // Eq. 3.25, p. 50 Js = J1 - J2
     volScalarField J1 = 3.0*alpha_*betaPrim;
+    /*
     volScalarField J2 =
         0.25*alpha_*sqr(betaPrim)*da_*sqr(Ur_)
        /(rhoa_*sqrtPi*ThetaSqrt);
+    */
 
     // bulk viscosity  p. 45 (Lun et al. 1984).
 // limit production


### PR DESCRIPTION
Trying to run a simulation where the Theta field is initialized to 0 causes sedFoam to crash with a floating-point divide-by-zero error in the kineticTheoryModel.

This is because "volScalarField J2 = ..." divides by ThetaSqrt, which is 0.

Since J2 isn't used anywhere else in the code, I just commented it out and it runs fine now.

There might be a better solution if J2 is required, like creating a ThetaSmall term (similar to alphaSmall), and then dividing by (ThetaSqrt+ThetaSmall).