### PR TITLE
Some changes to compile with OpenFOAM 7

### DIFF
--- a/solver/pEqn.H
+++ b/solver/pEqn.H
@@ -217,7 +217,12 @@ License
         );
 
         pEqn.setReference(pRefCell, getRefCellValue(p_rbgh, pRefCell));
+
+#if OFVERSION >= 700
+        pEqn.solve();
+#else
         pEqn.solve(mesh.solver(p_rbgh.select(pimple.finalInnerIter())));
+#endif
 
         if (pimple.finalNonOrthogonalIter())
         {

--- a/solver/sedFoam.C
+++ b/solver/sedFoam.C
@@ -146,29 +146,26 @@ int main(int argc, char *argv[])
             while (pimple.correct())
             {
                 #include "pEqn.H"
-                #if OFVERSION >= 600
-                    if (not pimple.finalPISOIter())
-                    {
-                        if (correctAlpha)
-                        {
-                            #include "alphaEqn.H"
-                        }
-                        #include "liftDragCoeffs.H"
-                        #include "callKineticTheory.H"
-                        #include "callFrictionStress.H"
-                    }
+
+                if
+                (
+                #if OFVERSION >= 700
+                    not pimple.finalPisoIter()
+                #elif OFVERSION >= 600
+                    not pimple.finalPISOIter()
                 #else
-                    if (pimple.corrPISO() < pimple.nCorrPISO())
-                    {
-                        if (correctAlpha)
-                        {
-                            #include "alphaEqn.H"
-                        }
-                        #include "liftDragCoeffs.H"
-                        #include "callKineticTheory.H"
-                        #include "callFrictionStress.H"
-                    }
+                    pimple.corrPISO() < pimple.nCorrPISO()
                 #endif
+                )
+                {
+                    if (correctAlpha)
+                    {
+                        #include "alphaEqn.H"
+                    }
+                    #include "liftDragCoeffs.H"
+                    #include "callKineticTheory.H"
+                    #include "callFrictionStress.H"
+                }
 
                 if (pimple.turbCorr())
                 {

--- a/solverMULES/sedFoam_MULES.C
+++ b/solverMULES/sedFoam_MULES.C
@@ -147,29 +147,27 @@ int main(int argc, char *argv[])
             while (pimple.correct())
             {
                 #include "pEqn.H"
-                #if OFVERSION >= 600
-                    if (not pimple.finalPISOIter())
-                    {
-                        if (correctAlpha)
-                        {
-                            #include "alphaEqn.H"
-                        }
-                        #include "liftDragCoeffs.H"
-                        #include "callKineticTheory.H"
-                        #include "callFrictionStress.H"
-                    }
+
+                if
+                (
+                #if OFVERSION >= 700
+                    not pimple.finalPisoIter()
+                #elif OFVERSION >= 600
+                    not pimple.finalPISOIter()
                 #else
-                    if (pimple.corrPISO() < pimple.nCorrPISO())
-                    {
-                        if (correctAlpha)
-                        {
-                            #include "alphaEqn.H"
-                        }
-                        #include "liftDragCoeffs.H"
-                        #include "callKineticTheory.H"
-                        #include "callFrictionStress.H"
-                    }
+                    pimple.corrPISO() < pimple.nCorrPISO()
                 #endif
+                )
+                {
+                    if (correctAlpha)
+                    {
+                        #include "alphaEqn.H"
+                    }
+                    #include "liftDragCoeffs.H"
+                    #include "callKineticTheory.H"
+                    #include "callFrictionStress.H"
+                }
+
                 if (pimple.turbCorr())
                 {
                     #include "updateTwoPhaseRASTurbulence.H"


### PR DESCRIPTION
Some functions changed in OpenFOAM 7:

`pEqn.solve` automatically selects the right solver for the final iteration.

`pimple.finalPISOIter` was renamed to `pimple.finalPisoIter`