### PR TITLE
COMP: use auto for runTime selection iterator type

### DIFF
--- a/solver/granularRheologyModels/FluidViscosityModel/FluidViscosityModel/newFluidViscosityModel.C
+++ b/solver/granularRheologyModels/FluidViscosityModel/FluidViscosityModel/newFluidViscosityModel.C
@@ -34,7 +34,7 @@ Foam::granularRheologyModels::FluidViscosityModel::New
     Info<< "Selecting FluidViscosityModel "
         << FluidViscosityModelType << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
+    auto cstrIter =
         dictionaryConstructorTablePtr_->find(FluidViscosityModelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())

--- a/solver/granularRheologyModels/FrictionModel/FrictionModel/newFrictionModel.C
+++ b/solver/granularRheologyModels/FrictionModel/FrictionModel/newFrictionModel.C
@@ -35,7 +35,7 @@ Foam::granularRheologyModels::FrictionModel::New
     Info<< "Selecting FrictionModel "
         << FrictionModelType << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
+    auto cstrIter =
         dictionaryConstructorTablePtr_->find(FrictionModelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())

--- a/solver/granularRheologyModels/PPressureModel/PPressureModel/newPPressureModel.C
+++ b/solver/granularRheologyModels/PPressureModel/PPressureModel/newPPressureModel.C
@@ -35,7 +35,7 @@ Foam::granularRheologyModels::PPressureModel::New
     Info<< "Selecting PPressureModel "
         << PPressureModelType << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
+    auto cstrIter =
         dictionaryConstructorTablePtr_->find(PPressureModelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())

--- a/solver/interfacialModels/dragModels/dragModel/newDragModel.C
+++ b/solver/interfacialModels/dragModels/dragModel/newDragModel.C
@@ -44,7 +44,7 @@ Foam::autoPtr<Foam::dragModel> Foam::dragModel::New
         << ": "
         << dragModelType << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
+    auto cstrIter =
         dictionaryConstructorTablePtr_->find(dragModelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())

--- a/solver/kineticTheoryModels/conductivityModel/conductivityModel/newConductivityModel.C
+++ b/solver/kineticTheoryModels/conductivityModel/conductivityModel/newConductivityModel.C
@@ -37,7 +37,7 @@ Foam::autoPtr<Foam::conductivityModel> Foam::conductivityModel::New
     Info<< "Selecting conductivityModel "
         << conductivityModelType << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
+    auto cstrIter =
         dictionaryConstructorTablePtr_->find(conductivityModelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())

--- a/solver/kineticTheoryModels/granularPressureModel/granularPressureModel/newGranularPressureModel.C
+++ b/solver/kineticTheoryModels/granularPressureModel/granularPressureModel/newGranularPressureModel.C
@@ -37,7 +37,7 @@ Foam::autoPtr<Foam::granularPressureModel> Foam::granularPressureModel::New
     Info<< "Selecting granularPressureModel "
         << granularPressureModelType << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
+    auto cstrIter =
         dictionaryConstructorTablePtr_->find(granularPressureModelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())

--- a/solver/kineticTheoryModels/radialModel/radialModel/newRadialModel.C
+++ b/solver/kineticTheoryModels/radialModel/radialModel/newRadialModel.C
@@ -37,7 +37,7 @@ Foam::autoPtr<Foam::radialModel> Foam::radialModel::New
     Info<< "Selecting radialModel "
         << radialModelType << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
+    auto cstrIter =
         dictionaryConstructorTablePtr_->find(radialModelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())

--- a/solver/kineticTheoryModels/viscosityModel/viscosityModel/newViscosityModel.C
+++ b/solver/kineticTheoryModels/viscosityModel/viscosityModel/newViscosityModel.C
@@ -38,7 +38,7 @@ Foam::kineticTheoryModels::viscosityModel::New
     Info<< "Selecting viscosityModel "
         << viscosityModelType << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
+    auto cstrIter =
         dictionaryConstructorTablePtr_->find(viscosityModelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())

--- a/solver/ppModel/newPpModel.C
+++ b/solver/ppModel/newPpModel.C
@@ -39,7 +39,7 @@ Foam::autoPtr<Foam::ppModel> Foam::ppModel::New
     Info << "Selecting ppModel "
         << ppModelType << endl;
 
-    dictionaryConstructorTable::iterator cstrIter =
+    auto cstrIter =
         dictionaryConstructorTablePtr_->find(ppModelType);
 
     if (cstrIter == dictionaryConstructorTablePtr_->end())


### PR DESCRIPTION
- avoid typedef dependency.  Works with any version (that uses C++11)
  but helpful for possible changes in OpenFOAM-v2112